### PR TITLE
Fix compatibility with Sailfish OS 3.3 (Rokua)+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 jolla-settings-screenmonitor.pro.user
 jolla-settings-screenmonitor.pro.autosave
+
+RPMS/

--- a/rpm/jolla-settings-screenmonitor.changes
+++ b/rpm/jolla-settings-screenmonitor.changes
@@ -8,6 +8,11 @@
 # * date Author's Name <author's email> version-release
 # - Summary of changes
 
+* Sun Jun 14 2020 Juanro49 <juanro.aof@gmail.com> 1.0.4-1
+- jolla-settings-screenmonitor.qml: Fix show percentages in DetailItems
+- jolla-settings-screenmonitor.yaml: Add nemo-qml-plugin-contextkit-qt5 dependency to fix compatibility with Sailfish OS 3.0.3 (Rokua)+
+- jolla-settings-screenmonitor.spec: Add nemo-qml-plugin-contextkit-qt5 dependency to fix compatibility with Sailfish OS 3.0.3 (Rokua)+
+
 * Thu Sep 06 2018 Eugenio "g7" Paolantonio <me@medesimo.eu> 1.0.3-1
 - [settings] Move to Nemo.DBus 2.0. Fixes compatibility with Sailfish OS 2.2.1 (Nurmonjoki)+
 

--- a/rpm/jolla-settings-screenmonitor.spec
+++ b/rpm/jolla-settings-screenmonitor.spec
@@ -13,7 +13,7 @@ Name:       jolla-settings-screenmonitor
 %{!?qtc_make:%define qtc_make make}
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    jolla-settings-screenmonitor
-Version:    1.0.3
+Version:    1.0.4
 Release:    1
 Group:      Applications/System
 License:    GPL2
@@ -21,6 +21,7 @@ URL:        http://me.medesimo.eu
 Source0:    %{name}-%{version}.tar.bz2
 Source100:  jolla-settings-screenmonitor.yaml
 Requires:   sailfishsilica-qt5 >= 0.10.9
+Requires:   nemo-qml-plugin-contextkit-qt5
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)

--- a/rpm/jolla-settings-screenmonitor.yaml
+++ b/rpm/jolla-settings-screenmonitor.yaml
@@ -1,6 +1,6 @@
 Name: jolla-settings-screenmonitor
 Summary: jolla-settings-screenmonitor
-Version: 1.0.3
+Version: 1.0.4
 Release: 1
 # The contents of the Group field should be one of the groups listed here:
 # http://gitorious.org/meego-developer-tools/spectacle/blobs/master/data/GROUPS
@@ -34,6 +34,7 @@ PkgBR:
 # Runtime dependencies which are not automatically detected
 Requires:
   - sailfishsilica-qt5 >= 0.10.9
+  - nemo-qml-plugin-contextkit-qt5
 
 # All installed files
 Files:

--- a/settings/jolla-settings-screenmonitor.qml
+++ b/settings/jolla-settings-screenmonitor.qml
@@ -160,7 +160,7 @@ Page {
 					   font.pixelSize: Theme.fontSizeHuge
 					   horizontalAlignment: Text.AlignHCenter
 					   verticalAlignment: Text.AlignVCenter
-					   text: qsTrId("settings_system-la-battery_level").arg(percentage)
+					   text: qsTrId("%1%").arg(percentage)
 				   }
 			   }
 
@@ -186,13 +186,13 @@ Page {
 		   DetailItem {
 			   width: parent.width
 			   label: qsTr("Battery")
-			   value: qsTrId("settings_system-la-battery_level").arg(batteryPercentage.value)
+			   value: qsTrId("%1%").arg(batteryPercentage.value)
 		   }
 
 		   DetailItem {
 			   width: parent.width
 			   label: qsTr("Brightness")
-			   value: qsTrId("settings_system-la-battery_level").arg(brightness)
+			   value: qsTrId("%1%").arg(brightness)
 		   }
 
 	   }


### PR DESCRIPTION
Fix compatibility with Sailfish OS 3.0.3 (Rokua)+ adding nemo-qml-plugin-contextkit-qt5 dependency and fixed percentages text.

**This pull request solve the issue #3** 

